### PR TITLE
Fix python packages in nginx image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,8 @@ WORKDIR /usr/src/app
 COPY requirements.txt .
 
 RUN apt update && apt install -y python3-pip \
-    && pip3 install --no-cache-dir -r requirements.txt \
-    && apt remove -y python3-pip \
-    && apt autoremove --purge -y \
-    && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/*.list
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir -r requirements.txt
 
 COPY setup.py .
 COPY src .


### PR DESCRIPTION
Stops removing pip, which breaks some python imports. 